### PR TITLE
Migrate Development Practices wiki to Architecture repo

### DIFF
--- a/practices/cicd/artifact-versioning.md
+++ b/practices/cicd/artifact-versioning.md
@@ -1,0 +1,3 @@
+# Versioning Approach
+
+See [Artifacts Versioning.pptx](https://osicagov.sharepoint.com/:p:/r/sites/TechnologyPlatformTeam2/_layouts/15/WopiFrame.aspx?sourcedoc=%7B3282CF58-693B-4C9E-B2AF-CFFDA014F02A%7D&file=Artifacts%20Versioning.pptx&action=default&IsList=1&ListId=%7B23359B33-C3B6-481F-A33C-027B0A464AB5%7D&ListItemId=17) (CWDS SharePoint link)

--- a/practices/cicd/pipeline.md
+++ b/practices/cicd/pipeline.md
@@ -1,0 +1,121 @@
+# Development Pipeline
+
+Below is a description of the development pipeline process planned for the CWS-Cares project. Much of this is already in place, but items not in place will be called out below. The expectation is that all teams will use this process. 
+
+1. For a given agile sprint, teams agree on, and pull stories from the JIRA backlog.
+1. Teams develop code and when complete, a "pull request" notifies the dev leads that a team member has made a change. The team lead(s) review the code and if all is well, allow the code to be merged into the main branch, and a checkin to Github is done. 
+1. The checkin process notifies the team’s CI server which starts a Jenkins process to compile code and run all the testing processes against the code. Static code analysis is performed automatically: Code Climate for front end teams, Sonarqube for API/Platform teams. 
+1. If the tests pass successfully, Jenkins kicks off a process to build the tested code into Docker Hub. A base Docker container is specified (e.g. RedHat Linux with Java pre-installed) and the code deployed into the Docker Container. At this point, a working Docker container is built and ready for deployment. Once the container has been built, each team lead can deloy the container into the preint environment. See Figure 1 Sample Environment below
+1. **[NEW]** Each team now has access to the "testing bubble". The full set of functional and/or acceptance tests can be run in the bubble, without affecting the ongoing testing and evaluation in the Pre-int environments.
+1. For a deployment into an integration testing environment, we currently use a manual process. At the release manager's request -- and after a team has tested their code in Preint -- a DevOps engineer will deploy a specified Docker container into an existing environment. When the new container is deployed, a series of automated tests are run against the container to both verify the environment configuration as well as to identify any regression defects. 
+1. **[NEW]** Each night all the functional testing containers will be run against the integration environment. The steps will be executed from a DevOps rundeck job: 
+   1. reset mainframe DB2 datasources
+   1. reset other data sources (Postgres, ElasticSearch, etc)
+   1. execute pipeline of testing containers, capturing and publishing all results
+   1. reset datasource back to baseline
+1. During the day, QA and SMEs will execute manual tests in both the CARES environments and legacy Integration environments. Any new tests identified are entered into team backlogs for inclusion in the automated testing containers. 
+1. When Functional testing has started (not completed) teams can request to promote code into Production where testing containers can run limited (performance flag ON?) performance tests (e.g. response time under load). 
+1. Only after functional testing is all passing, and performance tests have been created and run, is a release a candidate for discussion for going to Staging for evaluation.  
+
+To move from this point towards the production environment requires approval by, and coordination with, the project’s Release Manager. See Figure 2 CWDS Pipeline below
+1. Several different automated testing tools are used:
+    1. Junit – java unit tests for API
+    2. Jmeter – Java performance and functional tests for API
+    3. Selenium – automated front-end tests against a browser
+    4. Rspec – Rails testing tools for front-end
+
+![CWDS Containers](https://raw.githubusercontent.com/wiki/ca-cwds/architecture/images/containers.png)
+
+*Figure 1 Sample Environment*
+
+
+The diagram above is a picture of a sample environment. Docker containers are deployed into Virtual machines. VMs are created through DevOps scripts. 
+
+The picture below shows the CWDS pipeline. The target process will enable tested code to be deployed into increasingly production-like environments, and up on which automated/manual testing will be performed. As the tests are passed, code moves through the pipeline towards production. 
+
+![pipeline](https://raw.githubusercontent.com/wiki/ca-cwds/architecture/images/pipeline.png)
+
+*Figure 2 CWDS Pipeline*
+
+## Tools/Technologies used in CWDS CI/CD processes
+
+<table>
+  <tr>
+    <td>Performance Monitoring</td>
+    <td>New Relic</td>
+    <td>Performance monitoring of full application stack</td>
+  </tr>
+  <tr>
+    <td>Static Code Analysis</td>
+    <td>Code Climate</td>
+    <td>Code Climate is software as a service that provides static code analysis that is integrated with Github and provides constant feedback on source code quality, security exposures, and more. The TOS is negotiable for "enterprise" accounts.</td>
+  </tr>
+  <tr>
+    <td>Configuration management</td>
+    <td>AWS CloudFormation</td>
+    <td>Included of AWS subscription. CloudFormation uses JSON or YML formatted templates to define infrastructure components, which are then loaded into the CloudFormation engine and used to create the servers, networks, and security controls defined by a given template. 
+
+All templates created by the project use standard JSON, which is an open standard data markup language similar to XML.</td>
+  </tr>
+  <tr>
+    <td>Project management</td>
+    <td>Pivotal Tracker</td>
+    <td>Agile project management tool provided as a web-based subscription service (SAAS) at http://pivotaltracker.com/. This service has a TOS (link).</td>
+  </tr>
+  <tr>
+    <td>Version control</td>
+    <td>Github</td>
+    <td>GitHub is a web service with a free and paid subscription model that provides Source code version control tool based on the open source GIT project. This service has its own TOS (link). </td>
+  </tr>
+  <tr>
+    <td>Asset build tool</td>
+    <td>Webpack</td>
+    <td>Tool for compiling front end assets</td>
+  </tr>
+  <tr>
+    <td>Back-end build tool</td>
+    <td>Gradle</td>
+    <td>Open source build automation system that integrates with Jenkins</td>
+  </tr>
+  <tr>
+    <td>Configuration management</td>
+    <td>Ansible</td>
+    <td>Flexible IT configuration management framework.   </td>
+  </tr>
+  <tr>
+    <td>Continuous integration</td>
+    <td>Jenkins</td>
+    <td>Provides continuous integration services for software development.</td>
+  </tr>
+  <tr>
+    <td>Front-end build tool</td>
+    <td>Rake</td>
+    <td>Rails command line tool used for Rails builds</td>
+  </tr>
+  <tr>
+    <td>Asset & Dependency Management</td>
+    <td>jFrog Artifactory</td>
+    <td>Used to manage build assets as for code (Maven, Gradle) as well as deployment (Docker Registry, RPM and DEB repo)</td>
+  </tr>
+  <tr>
+    <td>Javascript build tool</td>
+    <td>Yarn</td>
+    <td>Tool for packaging Javascript assets</td>
+  </tr>
+  <tr>
+    <td>Docker Container Registry</td>
+    <td>Docker Hub</td>
+    <td>Repository for storing Docker images online in versioned repositories (public or private). The project uses DockerHub for the storage and distribution of non-production containers.
+
+Use of DockerHub will be replaced by Amazon Elastic Container Repository (ECR) for Release 2.</td>
+  </tr>
+  <tr>
+    <td>Package and deploy tools</td>
+    <td>Docker Toolbox</td>
+    <td>Tools for packaging software as Docker containers, provisioning machines and deploying containers. 
+
+Docker containers are managed by the Docker Engine on project application servers, which depend on built in capability of the Linux kernel (namespaces and cgroups)</td>
+  </tr>
+</table>
+
+

--- a/practices/db/add-data-to-db2.md
+++ b/practices/db/add-data-to-db2.md
@@ -1,0 +1,14 @@
+# Adding Data to DB2
+
+Data needed for testing or other uses can be added to the DB2 databases in the lower-order (development) environments. 
+
+In general, test cases should try to create their own data, and clean up when done, in order to reduce the possibility of test data pollution. However there will be cases when adding new data is required. Given this, its recommended to add new data for your specific testing, and not re-use existing data.
+
+By following the steps described at the [DB2data github repo](https://github.com/ca-cwds/db2data) you can get data added to the DB2 Docker container (for local development). This data will also be manually added to the DB2 mainframe baseline image. 
+The goal of this process is that when the DBs are refreshed, all environments will be reset to an identical image will contain what teams need for testing.   
+
+## NOTE ## 
+In some cases, you will not know how to construct the queries needed to correctly add data to CWS/CMS DB2 database. In this case, you will need to work with the DB2 DBAs. The steps are:
++ You (developer) work with a legacy SME to use the legacy app to add data needed. Once you confirm that the data can be added, contact the DBAs
++ The DBAs can prep the mainframe to capture sql logs. Then your legacy SME will repeat the steps to add needed data to the legacy. 
++ When done, the DBA can extract the captured SQL for you, and you can follow the [process described above](https://github.com/ca-cwds/db2data) for adding SQL to the DB2 Docker container via liquibase. 

--- a/practices/db/cwscms-upgrades.md
+++ b/practices/db/cwscms-upgrades.md
@@ -1,0 +1,12 @@
+# Upgrading CWS CARES to new DB2 schema version
+
+When the current CWS/CMS system is upgraded to support new release functionality, CWS-CARES needs to test and ensure the changes have been reviewed and are addressed in CARES. 
+ 
+**Steps**
++ IBM releases a new version of CWS/CMS DB2
++ CWS-CARES upgrades all environments to new version of DB as soon as it is convenient for IBM 
++ We will test our application using the new version and work to identify any errors
+
+Around Code Freeze Time (2 weeks before Go-Live)
++ CWS-CARES will keep our staging at the current (old) release of DB2. This will allow us to support current (old) system still in production 
++ During the week after the release (Go-Live weekend) of the new DB into CWS-CMS production, CARES will work with IBM to update our staging to the new version of DB2

--- a/practices/dev/Technology-Platform-Team-Orientation.md
+++ b/practices/dev/Technology-Platform-Team-Orientation.md
@@ -1,0 +1,114 @@
+# Technology Platform Team Orientation
+## 1. Access checklist
+### 1.1. Development
+* OSI email
+* Slack account in CWDS organization
+* [State SharePoint](https://osicagov.sharepoint.com/_layouts/15/sharepoint.aspx) (the same credentials as for OSI email) 
+* [GitHub](https://github.com/ca-cwds) account added to CWDS organization
+* [DockerHub](https://hub.docker.com/u/cwds/dashboard/) account added to CWDS organization
+* OpenVPN
+* SSH access to AWS environments (Pre-Int) 
+* [Kibana Logs](http://logs.cwds.io) for all dev environments (Pre-Int, Preview, Int) 
+* [Pre-Int Jenkins](http://jenkins.mgmt.cwds.io:8080/login) 
+* Access to development environments: [Pre-Int](web.preint.cwds.io), [Preview](preview.cwds.ca.gov), [Int](https://web.integration.cwds.io)
+* [Pivotal Tracker](https://www.pivotaltracker.com/n/projects/2011319)/ JIRA
+### 1.2. Legacy
+* CWS/CMS application ID
+* SAF account
+
+## 2. Coding and Indenting standards
+* Technology Platform Teams (TPT) adheres to [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html). IntelliJ IDEA plugin can be used to enforce Google Code Style. More about [Code Standards](https://github.com/ca-cwds/API/wiki/Coding-Standards).
+## 3. Code Quality and Naming conventions
+* We adhere to the coding approach described in the book [Clean Code by Robert Martin](https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882).
+* [Sonarqube](http://sonar.dev.cwds.io:9000/projects/favorite) is used by all TPT as code quality tool to enforce coding best practices. The common project quality gate is applied to all modules.
+## 4. Test Coverage
+* All TPT projects are covered by JUnit tests. Gradle is used to generate test report.
+* We are using JaCoCo for testing coverage measuring. More details on how you can integrate JaCoCo into the application [here](https://github.com/ca-cwds/cals-api/wiki/Code-Coverage-Approach).
+* The application shall be covered by unit tests and achieve **at least 70% of coverage**. 
+* JMeter for performance testing
+* Sonarqube with additional plugins for security static code analyses. Additional tools now are considered to be used for static and dynamic security scanning
+## 5. Development environment
+### 5.1. Desktop Security requirements
+CWDS Requirements for all vendor devices, each device (including your smartphones and tablets) used to access OSI or CWDS data or environments has several minimum requirements:
+
+* Whole Disk/Device Encryption
+* Anti-Malware/Security Software Installed and Updated
+* Lastest OS version is installed (and kept patched)
+* Device/OS Password enabled and changed every 90 days
+* Firewall enabled
+
+Strongly suggested the following:
+
+* Firewall - "Stealth mode" and Application Blocking enabled
+* Firewall -  Only essential services allowed access to the internet (outbound) or device (inbound)
+* Always use VPN - When using public Wi-Fi networks, you should always use a personal or company VPN. If you do not have either of these, use the free Opera Web browser (Win/Mac/Lin) which includes built-in VPN or the free Opera VPN (iOS/Android)
+
+### 5.2. Development Tools
+* [Java 8 SDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+* IDE - IntelliJ IDEA, Eclipse
+* IntelliJ IDEA SonarLint plugin for real-time static code analyses
+* IntelliJ IDEA Google-java-format for code formatting
+* [Docker Toolbox](https://www.docker.com/products/docker-toolbox) (select Kitematic during installation)
+
+## 6. Continuous Integration and Continuius Delivery
+
+* [Development Pipeline](https://osicagov.sharepoint.com/sites/projects/CWS-NS/releasemanagement/_layouts/15/WopiFrame.aspx?sourcedoc=%7Bbb79fd6b-acba-43a7-b20d-dcda49edcbbd%7D&action=interactivepreview)
+* [CI Pipeline](https://osicagov.sharepoint.com/sites/projects/CWS-NS/releasemanagement/_layouts/15/WopiFrame.aspx?sourcedoc=%7B84c02331-aa50-40ba-a94e-d75b52d2dea1%7D&action=interactivepreview)
+
+### 6.1. Jenkins pipeline
+* [CALS API pipeline example](http://jenkins.dev.cwds.io:8080/job/cals-api/) 
+* [Jenkins file example](https://github.com/ca-cwds/cals-api/blob/development/Jenkinsfile) 
+
+## 7. Project Structure
+### 7.1. Digital Services
+* Intake 
+* CALS 
+* Case Management 1
+* Case Management 2
+### 7.2. Technology Platform
+* TPT 1 - supports Intake team
+* TPT 2 - supports CALS team
+* TPT 3 - support Case Management teams
+### 7.3. Other Teams
+* DevOps
+* Implementation
+* External Interfaces and Data Team
+* DesignOps 
+
+## 8. Solution architecture
+* [Technology Stack](https://osicagov.sharepoint.com/sites/projects/CWS-NS/TST/_layouts/15/WopiFrame.aspx?sourcedoc=%7Bebf49d9e-1dfe-4c92-b9d5-e3e975cac3f7%7D&action=default&slrid=6a4c299e-50a5-4000-89fb-29fb96add4ad)
+* [Architectural Diagram](https://osicagov.sharepoint.com/sites/TechnologyPlatformTeam2/Shared%20Documents/Forms/AllItems.aspx?id=/sites/TechnologyPlatformTeam2/Shared%20Documents/Architecture/gateway.pdf&parent=/sites/TechnologyPlatformTeam2/Shared%20Documents/Architecture)
+* [Security Development Guide](https://osicagov.sharepoint.com/sites/TechnologyPlatformTeam2/_layouts/15/WopiFrame.aspx?sourcedoc=%7BEB8E8C6A-481B-49E3-A855-09DA49CF976B%7D&file=CWDS%20API%20Security%20Developer%27s%20Guide.docx&action=default)
+### 8.1. Technology Platform Components
+#### 8.1.1. TPT 1
+* [Ferb API](https://github.com/ca-cwds/API) - Intake Screening and Investigation
+#### 8.1.2. TPT 2
+* [CALS API](https://github.com/ca-cwds/cals-api) - Facility, RFA 
+* [Perry](https://github.com/ca-cwds/perry) - Authentication, Authorization, integration with SAF
+* [Dora API](https://github.com/ca-cwds/dora) - Search API based on Elasticsearch
+* [Geo Services API](https://github.com/ca-cwds/geo-services-api) - address validation, lookup, integration with SmartyStreets
+* [Document Management System API](https://github.com/ca-cwds/dms-api) - provides ability to create/update/delete documents, generate documents base on templates based on Nuxeo
+* [Forms API](https://github.com/ca-cwds/forms-api) - CRUD API for form based functionality
+
+#### 8.1.3. Shared Projects
+* [Neutron Jobs](https://github.com/ca-cwds/jobs) - ETL to load data from DB2 and Postgresql to Elasticsearch
+* [API Core](https://github.com/ca-cwds/api-core) - shared code used by other API modules
+* [DB2 Data](https://github.com/ca-cwds/db2data) - DB2 migration scripts
+
+### 8.2. API architecture
+* [Key architecture concepts](https://github.com/ca-cwds/API/wiki/Architecture-and-Design----Changes-and-Elaborations)
+
+### 8.3. Development Artifacts Versioning 
+[Naming convention for artifacts as jar libraries, Docker images, etc](https://osicagov.sharepoint.com/sites/TechnologyPlatformTeam2/_layouts/15/WopiFrame.aspx?sourcedoc=%7B3282CF58-693B-4C9E-B2AF-CFFDA014F02A%7D&file=Artifacts%20Versioning.pptx&action=default&IsList=1&ListId=%7B23359B33-C3B6-481F-A33C-027B0A464AB5%7D&ListItemId=17)
+
+## 9. FOSS
+* AGPL is currently selected as a target license for CWDS code base
+* Make sure you are using AGPL compliant open source licenses as Apachev2, MIT, BSD, LGPL
+* Do not use Eclipse Public License 1.0, CDDL, GPLv2
+
+## 10. Scrum
+### 10.1. Technical Debt
+[Analyzing, Identifying and Managing Technical Debt](https://osicagov.sharepoint.com/sites/projects/CWS-NS/Agile/_layouts/15/WopiFrame.aspx?sourcedoc=%7B0196183f-5a42-497a-8207-38ccfe86d58b%7D&action=default)
+
+## 11. Legacy Development
+* [Legacy Development Guide](https://osicagov.sharepoint.com/sites/TechnologyPlatformTeam2/_layouts/15/WopiFrame.aspx?sourcedoc=%7B7D553D6A-0A5B-4FEE-A2AE-CD6A8ED5D6F6%7D&file=Legacy%20Development%20Guide.docx&action=default&IsList=1&ListId=%7B23359B33-C3B6-481F-A33C-027B0A464AB5%7D&ListItemId=26) - work in-progress

--- a/practices/dev/code-climate-cfg-rails.md
+++ b/practices/dev/code-climate-cfg-rails.md
@@ -1,0 +1,42 @@
+# Code Climate configuration for React Rails projects
+
+
+```
+engines:
+  brakeman:
+    enabled: true
+  bundler-audit:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  eslint:
+    enabled: true
+    channel: eslint-3
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+    channel: rubocop-0-48
+ratings:
+  paths:
+  - "**.erb"
+  - "**.haml"
+  - "**.rb"
+  - "**.js"
+  - "**.jsx"
+exclude_paths:
+- bin/
+- config/
+- db/
+- docker/
+- karma.conf.js
+- legal/
+- lib/tasks/
+- log/
+- public/
+- spec/
+- vendor/
+```

--- a/practices/dev/cwds-code-branching.md
+++ b/practices/dev/cwds-code-branching.md
@@ -1,0 +1,8 @@
+# CWDS Code Branching Approach
+
+This is current default practice for our branching strategy:
+
+* We favor [trunk based](https://trunkbaseddevelopment.com) development to enable CI/CD.
+* Feature branches are used, but should generally not live past a single sprint.
+* Releases are simply tagged as a commit on the master branch.
+* Release branches are created if needed to fix bugs in production but should be as short-lived as possible as this is an exception process.

--- a/practices/dev/dev-guide.md
+++ b/practices/dev/dev-guide.md
@@ -1,0 +1,6 @@
+# Development Guide
+[This development guide]( https://osicagov.sharepoint.com/:w:/r/sites/TechnologyPlatformTeam2/_layouts/15/WopiFrame.aspx?sourcedoc=%7B7D553D6A-0A5B-4FEE-A2AE-CD6A8ED5D6F6%7D&file=Legacy%20Development%20Guide.docx&action=default&IsList=1&ListId=%7B23359B33-C3B6-481F-A33C-027B0A464AB5%7D&ListItemId=26) provides an overview of the resources and tools used by developers on CWDS. This guide is more focused on API development, but the content applies will help both front and back-end developers who are interacting with the legacy CWS/CMS system. 
+
+[Click here for even more information](Technology-Platform-Team-Orientation.md) about API development, and the tools and processes used at CWDS.
+
+Another helpful source of information is the [Data Management sharepoint site](https://osicagov.sharepoint.com/sites/projects/CWS-NS/datamgmt/SitePages/Home.aspx ). One of the key link on this site is the downloadable version of [ Doctools](https://osicagov.sharepoint.com/sites/projects/CWS-NS/datamgmt/SitePages/Home.aspx )

--- a/practices/dev/jira-workflow.md
+++ b/practices/dev/jira-workflow.md
@@ -1,0 +1,62 @@
+# Jira Workflow Notes
+
+# Overview
+Draft criteria for steps in the Jira workflow from meeting on December 4, 2017.
+
+# Definitions of Done
+
+## To Do - Definition of Ready (Definition of Done not applicable)
+Not discussed
+
+## Development
+Not discussed except to note the inclusion of the following elements
+* Automated feature/request tests
+* Automated unit tests
+* mocked API responses
+
+## Review
+Not discussed
+
+## Testing - Definition of Ready (possible Definition of Done for new column: Merge/Deploy)
+* Code merged into master branch (Note: base branch for merging might be changed at a later date)
+* Deployed to appropriate testing environment (Suggestion: Define test environment at time of story refinement)
+  * Pre-int / Pre-int02 - Stories that do not affect the legacy client
+  * Integration / Integration 02 - Stories that need to be tested using the legacy client
+
+## Testing
+* Any member of the team (other than original developer and product owner) can test a story
+* Manually confirm story meets all acceptance criteria
+* Manually run appropriate edge cases
+  * Focus on things a "normal" user would do
+  * Example of appropriate: Leap year checking
+  * Example of inappropriate: SQL Injection
+* Write detailed testing summary in story
+  * Scenario tested and result of scenario (provide short description of failing behavior)
+    * Example of passing scenario: Should reject invalid date (11/31/2017) - Passed
+    * Example of failing scenario: Should reject invalid date (11/31/2017) - Failed: app set date to 12/1/2017
+
+Note: Tester does not accept/reject the story. Product owner will review the testing summary as part of accept/reject decision.
+
+Note: For wood duck stories the testing column in jira is not used as the process is:
+* PR code review by Ed, Bruno, or Nesh
+* PR design review by Kristina & Alyssa
+* Test, review, and acceptance by Gregg (PO for design ops) to get to done.
+
+### Out of scope for Testing steps
+* Performance
+* Security
+* Load
+
+## PO Review
+Not discussed
+
+## Done
+Not discussed
+
+# QA Team/Role Parking Lot
+* Focus of dedicated QA Resources
+* Champion automated framework
+* How to test integrated app w/out mocked data
+* Scope of regressions tests
+* Scope of any one test
+* How to test E2E stories

--- a/practices/dev/kibana-logs-tips.md
+++ b/practices/dev/kibana-logs-tips.md
@@ -1,0 +1,36 @@
+# Kibana Logs Tips
+
+## Log Search
+### Save Search
+You can create and save search queries for your application in all environments and then use them to open your logs quickly. 
+1. Use menu Discover on the left, pick index from drop-down which corresponds to the needed environment 
+![](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/pick_environment.png)
+2. Select docker image name with your application
+![](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/select_docker_name.png)
+3. Save search with proper name
+![](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/save_search.png)
+### Pre-Saved Searches
+It is easy to use pre-saved search queries to see some logs 
+![Open Search](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/open_search.png)
+### Quick Time Range 
+You can change time range for search
+![Quick Time Range](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/quick_time_range.png)
+### Absolute Time Range
+Absolute time range can help to search logs in particular time range
+![Absolute Time Range](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/absolute_time_range.png)
+### Search by content
+Simplest search query to find an exact match in logs. Can be a good starting point.
+![Search by content](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/search_by_content.png)
+### Surrounding Messages
+Kibana provides ability to open surrounding messages around some message which you found.
+![](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/surrounding_messages.png)
+You can show as many lines before and after message as you need to understand the context of log message
+![](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/surrounding_messages_1.png)
+
+## Log view
+Regular log view can be too messy 
+![](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/regular_log_view.png)
+To improve log readability you can use message as key part of log to eliminate other log elements which create noise
+![](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/message_view.png)
+As a result, logs will be more readable
+![](https://github.com/ca-cwds/development-practices/blob/master/images/kibana/message_view_1.png)

--- a/practices/dev/new-api-functional-tests.md
+++ b/practices/dev/new-api-functional-tests.md
@@ -1,0 +1,9 @@
+
+# Building new API functional tests
+After discussion with the team, automated API tests will be constructed with **junit, running through a REST client**. Originally jmeter had been used for some functional tests. While well suited for performance testing, using jmeter for functional testing was limiting. The teams decided to use junit tests. 
+
+Integration testing containers will be constructed to run stand-alone, executing junit tests that load environment variables and execute tests against a target environment. 
+
+[TBD -- add info from Bruno/Nesh on automated front-end testing tools]
+
+Teams will need to work to coordinate test coverage; there is no need to have front-end selenium testing containers execute the same tests run by the API test containers. 

--- a/practices/dev/reusable-api-comp.md
+++ b/practices/dev/reusable-api-comp.md
@@ -1,0 +1,8 @@
+# Finding Reuseable API Components
+
+All teams on the project need to first look at using components that have already been built when responding to new requests. To help see what has been built, the swagger.json files for each API have been combined into one and made available to view. 
+
+**[Click here (updated 2/26/2018)](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/ca-cwds/development-practices/master/docs/combined-02-26-18.json)** to see the swagger documentation for the CALS, Dora, and Ferb API. 
+
+I'll add in CM soon. We'll work to make this available automatically as part of the build process. But for now, this may help both designers and developers to see details of the services that have been built. 
+

--- a/practices/dev/sonarqube-cfg.md
+++ b/practices/dev/sonarqube-cfg.md
@@ -1,0 +1,2 @@
+# SonarQube configuration
+Work in-progress

--- a/practices/dev/tech-debt.md
+++ b/practices/dev/tech-debt.md
@@ -1,0 +1,9 @@
+# Technical Debt
+
+Technical debt is a common part of every development project, but the specifics involved in measuring it are quite varied. For purposes of CWDS projects:
+
+* Track technical debt by creating user stories in our JIRA trackers
+* Stories will be labeled with `tech-debt` and using a prefix in the story title of **TECH DEBT:**. 
+* For now, there is an underlying assumption that about 10% of development stories will be devoted to tracking technical debt.
+
+Measures such as technical debt determined by CodeClimate metrics will also be explored for helping to define technical debt on the project. These methods are likely to be adjusted over time.

--- a/practices/doc/practice-style-guide.md
+++ b/practices/doc/practice-style-guide.md
@@ -1,0 +1,26 @@
+# Practices Style Guide
+
+## Standard Page Template
+The following template can be used as a starting point for your new pages.
+```
+# {Page Title}
+## Contents
+{Table of Contents - for long documents}
+  * [Anchor link](#anchor-target)
+  
+## Sub-head
+{Sub-head content}
+```
+
+## New Content
+  1. Create a new branch in this repository
+  1. New content should be added to the practices library in Github-compatible markdown format.
+  1. New pages must be created in a branch, and then submitted via pull request
+  1. Add a link to your new content in the [Practices `readme.md`](../readme.md) file
+  1. Create a pull request to merge your changes into the `Master` branch
+
+## Embedded Images
+If your images are stored remotely, you can link to them directly from your page. However, if the image needs to be stored/versioned with your page, you can add it to the [[../img/]] directory and then link to it from there.
+
+## Relative Hyperlinks
+All hyperlinks to content in this repository should use relative links, so that your links point to content in the the same branch. Links to pages and material in other branches should use absolute (full) links.

--- a/practices/readme.md
+++ b/practices/readme.md
@@ -1,8 +1,29 @@
 # Development Practices
-This directory contains development practices that have been adopted by the project for the purpose of defining standard ways to accomplish our work. The practices, once defined and adopted, will be implemented by development teams for new work, or identified as technical debt when refactoring is required.
+The Development Practices wiki contains development-related practices and standards that have been adopted by the project for the purpose of defining standard ways to accomplish our work. A practice, once defined and adopted, will be implemented by development teams for new work, or identified as technical debt when refactoring is required.
 
-# Getting new Practices Adopted
-To add or modify a development practice:
-  * Create a new branch and add/modify the practice document. 
-  * Create a pull request, and describe the change
-  * Get the pull request approved by a repo owner
+## Getting Started
+This wiki is a place for documenting agreements and practices across the various development teams contributing code to CWDS projects. It is designed to be a living document that will evolve over time. The two pages below are where we recommend that you start your journey.
+   * *Contribute:* Read the [Practices Style Guide](doc/practice-style-guide.md) to learn the _what_ and _how_ of new submissions
+   * *Team Members:* A good place to start is the [Development Guide](dev-guide.md).
+
+-----
+# Table of Contents
+## Continuous Delivery/Continuous Integration (CI/CD)
+  * [Development Pipeline - Overview](cicd/pipeline.md)
+  * [Versioning Approach](cicd/artifact-versioning.md)
+
+## Development
+  * [Development Guide](dev-guide.md) <-- Start Here
+  * [Building new API functional tests](dev/new-api-functional-tests.md)
+  * [Code Climate configuration for React Rails projects](dev/code-climate-cfg-rails.md)
+  * [Technology Platform Team Orientation](dev/Technology-Platform-Team-Orientation.md)
+  * [CWDS Code Branching Approach](dev/cwds-code-branching.md)
+  * [Finding Reuseable API Components](dev/reusable-api-comp.md)
+  * [Jira Workflow Notes](dev/jira-workflow.md)
+  * [Kibana Logs Tips](dev/kibana-logs-tips.md)
+  * [SonarQube Configuration](dev/sonarqube-cfg.md) *WIP*
+  * [Technical Debt](dev/tech-debt.md)
+
+## Databases
+  * [Adding Data to DB2](add-data-to-db2.md)
+  * [Upgrading CWS CARES to new DB2 schema version](db/cwscms-upgrades.md)

--- a/practices/readme.md
+++ b/practices/readme.md
@@ -1,0 +1,8 @@
+# Development Practices
+This directory contains development practices that have been adopted by the project for the purpose of defining standard ways to accomplish our work. The practices, once defined and adopted, will be implemented by development teams for new work, or identified as technical debt when refactoring is required.
+
+# Getting new Practices Adopted
+To add or modify a development practice:
+  * Create a new branch and add/modify the practice document. 
+  * Create a pull request, and describe the change
+  * Get the pull request approved by a repo owner


### PR DESCRIPTION
I copied all of the existing wiki pages from the "development-practices" repo and created a new entry-point called "readme.md". This model allows us to eliminate a variety of repositories that exist only for the use of their wiki, and consolidates our practices under the "architecture" repository. I also tested image links to make sure that they work (syntax had to be modified in a couple of cases).

Merging in these changes will not remove the existing wiki.

TODO:
  1. copy images from development-practices wiki and modify pages that refer to the images to use the `./practices/img/` directory
  1. Socialize and promote the new location and contribution process
  1. Retire/archive the "development-practices" repository.
  1. Continue to migrate content from other repositories, as appropriate, to promote local/repo-level practices to project-level practices.
 
