### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @ca-cwds/architecture
+
+# Root of Practices directory, includes all subdirectories and files
+/practices/ @ca-cwds/architecture
+
+# Root of CICD directory, to allow DevOps teams to approve practices added 
+# to the CI/CD directory
+/practices/cicd/  @ca-cwds/devops-eng


### PR DESCRIPTION
This file allows us to control who can approve a pull request. This version covers "global" as well as showing how we can include owners for different practices levels.

This file allows us to control who can approve a pull request, which allows more people to work in the repo to collaborate and contribute. We also need to update the repo collaborators list to give developers `write` access to the repo, so they can contribute without having to fork the whole repo.